### PR TITLE
Refactored Renaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,7 @@ name = "autorenamer"
 version = "1.0.3"
 dependencies = [
  "clap",
+ "lazy_static",
  "regex",
 ]
 
@@ -125,6 +126,12 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.20", features = ["derive"] }
+lazy_static = "1.5.0"
 regex = "1.11.1"


### PR DESCRIPTION
As title.

Refactors the renaming process from one large, rather confusing function that does everything into a few different locations, mainly:

- Adds a pair of match arms to main so that `rename_episodes` doesn't need to take a `Result<Vec<String>>` but instead just a `Vec<String>`
- Creates `Struct SeasonData` that has a `new` and `process_episodes` impl functions that takes the majority of the body of the renaming logic and puts it in a more legible location
- Minor performance improvements