### PR TITLE
Refactor to use nom parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -65,7 +65,7 @@ name = "autorenamer"
 version = "1.0.3"
 dependencies = [
  "clap",
- "lazy_static",
+ "nom",
  "regex",
 ]
 
@@ -128,16 +128,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.20", features = ["derive"] }
-lazy_static = "1.5.0"
+nom = "7.1.3"
 regex = "1.11.1"

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,51 +1,42 @@
-use lazy_static::lazy_static;
-use regex::Regex;
+use crate::parsing::parse_episode;
 use std::{error::Error, ffi::OsStr, path::Path};
-
 #[derive(Debug)]
-pub(crate) struct Episode {
-    pub(crate) old_path: String,
+pub struct Episode {
+    pub old_path: String,
     new_path: String,
 }
 impl Episode {
     fn new(old_path: String, new_path: String) -> Episode {
         Episode { old_path, new_path }
     }
-    pub(crate) fn create_ext(&self) -> String {
+    pub fn create_ext(&self) -> String {
         Path::new(&self.old_path)
             .extension()
             .and_then(OsStr::to_str)
             .unwrap_or("mp4")
             .to_string()
     }
-    pub(crate) fn create_new_path(&self, base_path: String, ext: String, file: String) -> String {
-        println!(
-            "\x1b[31m{}\x1b[0m => \x1b[35m{}.{}\x1b[0m",
-            file, &self.new_path, ext
-        );
-        format!("{}/{}.{}", base_path, &self.new_path, ext)
+    pub fn create_new_path(&self, file: &String, ext: String, print: bool) -> String {
+        if print {
+            println!(
+                "\x1b[31m{}\x1b[0m => \x1b[35m{}.{}\x1b[0m",
+                file, &self.new_path, ext
+            );
+        }
+        format!("{}.{}", &self.new_path, ext)
     }
-}
-
-lazy_static! {
-    static ref EPISODE_REGEX: Regex = Regex::new(r"(Episode [0-9]{1,5})(.*?)(\.)").unwrap();
 }
 
 #[derive(Debug)]
 pub struct SeasonData<'a> {
-    pub(crate) file: &'a str,
+    pub file: &'a str,
     season: i32,
     base_path: &'a str,
     offset: i32,
 }
 
 impl<'a> SeasonData<'a> {
-    pub(crate) fn new(
-        file: &'a str,
-        season: i32,
-        base_path: &'a str,
-        offset: i32,
-    ) -> SeasonData<'a> {
+    pub fn new(file: &'a str, season: i32, base_path: &'a str, offset: i32) -> SeasonData<'a> {
         SeasonData {
             file,
             season,
@@ -53,32 +44,34 @@ impl<'a> SeasonData<'a> {
             offset,
         }
     }
+    /**
+     Process the episode by parsing the episode file, adjusting the episode number based on the offset,
+     and creating a new path for the episode file.
+
+     This function takes no parameters and returns a Result containing an Episode on success or a Box<dyn Error> on failure.
+
+     # Errors
+
+     This function can return an error if there is an issue parsing the episode file or creating the new path.
+
+     # Examples
+
+    **/
     pub fn process_episode(&self) -> Result<Episode, Box<dyn Error>> {
-        // Check for matches in the file name
-        if let Some(captures) = EPISODE_REGEX.captures(self.file) {
-            // Extract episode number
-            if let Some(matched_str) = captures.get(1) {
-                let episode_str = &matched_str.as_str()[8..]; // "Episode " is 8 chars long
-                if let Ok(episode_num) = episode_str.parse::<i32>() {
-                    // Adjust episode number by the offset
-                    let new_episode_num = episode_num + self.offset;
-                    let mut new_path = format!("S{:0>2}E{:0>2}", self.season, new_episode_num);
-                    let description = captures.get(2).map(|m| m.as_str().trim()).unwrap_or("");
-                    if !description.is_empty() {
-                        new_path = format!("{} {}", new_path, description);
-                    }
-                    let old_name = format!("{}/{}", self.base_path, self.file);
-                    Ok(Episode::new(old_name, new_path))
-                } else {
-                    Err(format!("Failed to parse episode number in '{}'", self.file).into())
+        match parse_episode(self.file) {
+            Ok((_, (episode_num, title))) => {
+                let new_episode_num = episode_num + self.offset;
+                let mut new_path = format!(
+                    "{}/S{:0>2}E{:0>2}",
+                    self.base_path, self.season, new_episode_num
+                );
+                if !title.is_empty() {
+                    new_path = format!("{} {}", new_path, title);
                 }
-            } else {
-                Err(format!("Pattern not found in '{}'", self.file).into())
+                let old_name = format!("{}/{}", self.base_path, self.file);
+                Ok(Episode::new(old_name, new_path))
             }
-        } else if Path::new(&self.file).extension().is_none() {
-            Err(format!("File '{}' has no extension, skipping!", self.file).into())
-        } else {
-            Err(format!("Pattern not found in '{}'", self.file).into())
+            Err(err) => Err(Box::<dyn Error>::from(err.to_string())),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,14 +68,14 @@ fn rename_episodes(files: Vec<String>, season: i32, base_path: String, offset: i
             Ok(data) => {
                 let new_name = data.create_new_path(&file, data.create_ext(), false);
                 if new_name != data.old_path {
-                if !dryrun {
-                    let _ = fs::rename(
-                        &data.old_path,
-                        data.create_new_path(&file, data.create_ext(), true),
-                    );
-                } else {
-                    data.create_new_path(&file, data.create_ext(),true);
-                }
+                    if !dryrun {
+                        let _ = fs::rename(
+                            &data.old_path,
+                            data.create_new_path(&file, data.create_ext(), true),
+                        );
+                    } else {
+                        data.create_new_path(&file, data.create_ext(), true);
+                    }
                 }
             }
             Err(err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use clap::Parser;
 use std::{env, error::Error, fs};
 mod data;
+mod parsing;
 use crate::data::SeasonData;
+use regex::Regex;
 
 #[derive(Debug, Parser)]
 #[clap(name = "Autorenamer", version = "1.0.3", author = "HirschBerge")]
@@ -36,17 +38,17 @@ pub struct Autorename {
 }
 
 fn get_episodes(path: String) -> Result<Vec<String>, Box<dyn Error>> {
+    let re = Regex::new(r"(Episode \d{1,5}|E\d{1,5})")?;
     let mut matching_files: Vec<String> = fs::read_dir(path)?
         .flatten() // Flattens the Result<DirEntry, io::Error> into DirEntry by ignoring errors
         .filter_map(|file| {
             let path = file.path();
             if path.is_file() {
-                // Check for "Episode " in the file name
-                // TODO: Include files with "^E[0-9]{2,3}" so that already-processed files can be included.
                 if let Some(file_name) = path.file_name() {
                     let file_name_str = file_name.to_string_lossy();
-                    if file_name_str.contains("Episode ") {
-                        return Some(file_name_str.to_string()); // Push the matching file name
+                    // Check if the file name matches the regex
+                    if re.is_match(&file_name_str) {
+                        return Some(file_name_str.to_string());
                     }
                 }
             }
@@ -64,17 +66,16 @@ fn rename_episodes(files: Vec<String>, season: i32, base_path: String, offset: i
         let parsed_data = current_episode.process_episode();
         match parsed_data {
             Ok(data) => {
+                let new_name = data.create_new_path(&file, data.create_ext(), false);
+                if new_name != data.old_path {
                 if !dryrun {
                     let _ = fs::rename(
                         &data.old_path,
-                        data.create_new_path(
-                            base_path.clone(),
-                            data.create_ext(),
-                            current_episode.file.to_string(),
-                        ),
+                        data.create_new_path(&file, data.create_ext(), true),
                     );
                 } else {
-                    data.create_new_path(base_path.clone(), data.create_ext(), file);
+                    data.create_new_path(&file, data.create_ext(),true);
+                }
                 }
             }
             Err(err) => {
@@ -185,6 +186,7 @@ mod tests {
         create_test_file(temp_dir, "Episode 1.mp3");
         create_test_file(temp_dir, "Episode 2.mp3");
         create_test_file(temp_dir, "Episode 69.mp3");
+        create_test_file(temp_dir, "S22E73 A Massive Change.mp3");
         create_test_file(temp_dir, "Not_An_Episode.mp3");
         // Call the function and check the result
         let result = get_episodes(temp_dir.to_string());
@@ -192,7 +194,7 @@ mod tests {
         cleanup_temp_directory(temp_dir);
         assert!(result.is_ok());
         let matching_files = result.unwrap();
-        assert_eq!(matching_files.len(), 3);
+        assert_eq!(matching_files.len(), 4);
         // assert!(matching_files.contains(&"Episode 1.mp3".to_string()));
         // assert!(matching_files.contains(&"Episode 2.mp3".to_string()));
     }
@@ -207,6 +209,7 @@ mod tests {
         // Create some files with "Episode" in the name
         create_test_file(temp_dir, "Episode 1 Has a name.mp3");
         create_test_file(temp_dir, "Episode 2 Has a name also.mp3");
+        create_test_file(temp_dir, "S01E03 This a name also.mp3");
         create_test_file(temp_dir, "Episode 69 NIIIICE.mp3");
         create_test_file(temp_dir, "Not_An_Episode.mp3");
         // Call the function and check the result
@@ -222,9 +225,9 @@ mod tests {
         // Clean up: Delete the temporary directory and its contents
         let matching_files = get_filenames_in_directory(temp_dir).unwrap();
         cleanup_temp_directory(temp_dir);
-
         assert!(matching_files.contains(&"S01E01 Has a name.mp3".to_string()));
         assert!(matching_files.contains(&"S01E02 Has a name also.mp3".to_string()));
+        assert!(matching_files.contains(&"S01E03 This a name also.mp3".to_string()));
         assert!(matching_files.contains(&"S01E69 NIIIICE.mp3".to_string()));
     }
     #[test]

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,0 +1,82 @@
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take_until},
+    character::complete::{digit1, space1},
+    combinator::map_res,
+    IResult,
+};
+
+/// Parses a string input to extract an episode number and title.
+///
+/// This function takes a string input and attempts to parse it to extract an episode number and title. The input should be in the format of either "Episode <number>: <title>" or "E<number>: <title>". The function will return a tuple containing the episode number as an i32 and the title as a string reference.
+///
+/// # Arguments
+///
+/// * `input` - A string slice that contains the episode information in the format "Episode <number>: <title>" or "E<number>: <title>"
+///
+/// # Returns
+///
+/// A Result containing a tuple with the episode number as an i32 and the title as a string reference. If successful, it returns Ok((episode_number, episode_title)). If parsing fails, it returns an error.
+///
+/// # Examples
+///
+///
+pub fn parse_episode(input: &str) -> IResult<&str, (i32, &str)> {
+    // NOTE: Try to find either "Episode" or "E" followed by the number and title
+    alt((parse_new_episode, reparse_episode))(input)
+}
+
+/// Parses a full episode string and returns a tuple containing the episode number and title.
+///
+/// # Arguments
+///
+/// * `input` - A string slice that represents the full episode string to be parsed.
+///
+/// # Returns
+///
+/// Returns a `Result` with a tuple containing the episode number as an `i32` and the title as a `&str`.
+///
+/// # Errors
+///
+/// Returns an error if parsing fails or if the input string does not match the expected format.
+///
+/// # Examples
+///
+///
+pub fn parse_new_episode(input: &str) -> IResult<&str, (i32, &str)> {
+    let (input, _) = take_until("Episode")(input)?;
+    let (input, _) = tag("Episode")(input)?;
+    let (input, _) = space1(input)?;
+    let (input, episode_number) = map_res(digit1, str::parse::<i32>)(input)?;
+    let (input, title) = take_until(".")(input)?;
+    let (input, _) = tag(".")(input)?;
+
+    Ok((input, (episode_number, title.trim())))
+}
+
+/// Parses a string representing an episode into its episode number and title.
+///
+/// # Arguments
+///
+/// * `input` - A string slice that contains the episode information in the format "E<number>.<title>"
+///
+/// # Returns
+///
+/// Returns a tuple containing the remaining input string and a tuple with the episode number and title.
+///
+/// # Errors
+///
+/// Returns an error if the input string does not match the expected format.
+///
+/// # Examples
+///
+///
+pub fn reparse_episode(input: &str) -> IResult<&str, (i32, &str)> {
+    let (input, _) = take_until("E")(input)?;
+    let (input, _) = tag("E")(input)?;
+    let (input, episode_number) = map_res(digit1, str::parse::<i32>)(input)?;
+    let (input, title) = take_until(".")(input)?;
+    let (input, _) = tag(".")(input)?;
+
+    Ok((input, (episode_number, title.trim())))
+}


### PR DESCRIPTION
I didn't enjoy working with regex in this case since it is kind of clunky in rust, I find.
Nom has always been kind of cool to me, so I decided to try it out.
Performance is roughly the same, but I do find it a bit easier to work with, and it helped create an easier, and more flexible way to actually parse out multiple values (episode number, and title when applicable). While i was not entirely able to phase out regex as it actually does have a use when determining if either of two options are true (filtering down the file options when creating the vec

Other improvements
- When a rename would not make a change, does not print out to console, and does not attempt to rename
- Improvements to tests
- Improvements to readability
- Improvements to docstrings on various function